### PR TITLE
pop-to-buffer should return the buffer.

### DIFF
--- a/ecb-layout.el
+++ b/ecb-layout.el
@@ -1879,7 +1879,7 @@ for current layout."
            (select-window (display-buffer (ad-get-arg 0)
                                           (ad-get-arg 1)))
            ;; TODO: Klaus Berndl <klaus.berndl@sdm.de>: Do we need this?!
-           (set-buffer (ad-get-arg 0))
+           (setq ad-return-value (set-buffer (ad-get-arg 0)))
            (if (ad-get-arg 2)
                ;; not the best solution but for now....
                (bury-buffer (ad-get-arg 0))))


### PR DESCRIPTION
Ensures that all branches of ECB's pop-to-buffer advice will return the buffer popped to.

I was having some issues using SLIME's trace functionality with ECB. I tracked it down to ECB's advice for pop-to-buffer not always returning the buffer popped to. This should fix that.